### PR TITLE
Frac reduce fail if numerator is 0

### DIFF
--- a/frac.go
+++ b/frac.go
@@ -45,5 +45,8 @@ func (f Frac) Reduce() Frac {
 	for r != 0 {
 		gcd, r = r, gcd%r
 	}
+	if gcd == 0 {
+		gcd = 1
+	}
 	return Frac{f.N / gcd, f.D / gcd}
 }


### PR DESCRIPTION
A division by 0 happens if the numerator is 0:
panic: runtime error: integer divide by zero

goroutine 1 [running]:
github.com/korandiz/v4l.Frac.Reduce(0x0, 0xc0d05605)
	/go/pkg/mod/github.com/korandiz/v4l@v0.0.0-20180520170035-995f703bfc89/frac.go:48 +0x5a
github.com/korandiz/v4l.(*Device).SetConfig(0xc00000e0b8, 0x47504a4d, 0x280, 0x1e0, 0x0, 0x0, 0x0)